### PR TITLE
Corrected endianness at read data. (#3332)

### DIFF
--- a/src/c/profile/session/read_access.c
+++ b/src/c/profile/session/read_access.c
@@ -103,6 +103,7 @@ inline void read_format_data(mrSession* session, MicroBuffer* payload, uint16_t 
 
     MicroBuffer mb_topic;
     init_micro_buffer(&mb_topic, payload->iterator, length);
+    mb_topic.endianness = payload->endianness;
     session->on_topic(session, object_id, request_id, stream_id, &mb_topic, session->on_topic_args);
 }
 


### PR DESCRIPTION
Before giving a topic to the user, a new MicroBuffer struct is created from the internal stream Microbuffer. The new MicroBuffer did not have the same endianness value.