### PR TITLE
Request API change

### DIFF
--- a/include/micrortps/client/core/session/session.h
+++ b/include/micrortps/client/core/session/session.h
@@ -66,7 +66,7 @@ MRDLLAPI mrStreamId mr_create_output_reliable_stream(mrSession* session, uint8_t
 MRDLLAPI mrStreamId mr_create_input_best_effort_stream(mrSession* session);
 MRDLLAPI mrStreamId mr_create_input_reliable_stream(mrSession* session, uint8_t* buffer, size_t size, uint16_t history);
 
-MRDLLAPI void flash_output_streams(mrSession* session);
+MRDLLAPI void mr_flash_output_streams(mrSession* session);
 MRDLLAPI bool mr_run_session_time(mrSession* session, int time);
 MRDLLAPI bool mr_run_session_until_timeout(mrSession* session, int timeout);
 MRDLLAPI bool mr_run_session_until_confirm_delivery(mrSession* session, int timeout);

--- a/include/micrortps/client/core/session/session.h
+++ b/include/micrortps/client/core/session/session.h
@@ -66,7 +66,9 @@ MRDLLAPI mrStreamId mr_create_output_reliable_stream(mrSession* session, uint8_t
 MRDLLAPI mrStreamId mr_create_input_best_effort_stream(mrSession* session);
 MRDLLAPI mrStreamId mr_create_input_reliable_stream(mrSession* session, uint8_t* buffer, size_t size, uint16_t history);
 
-MRDLLAPI bool mr_run_session_until_timeout(mrSession* session, int tiemout);
+MRDLLAPI void flash_output_streams(mrSession* session);
+MRDLLAPI bool mr_run_session_time(mrSession* session, int time);
+MRDLLAPI bool mr_run_session_until_timeout(mrSession* session, int timeout);
 MRDLLAPI bool mr_run_session_until_confirm_delivery(mrSession* session, int timeout);
 MRDLLAPI bool mr_run_session_until_status(mrSession* session, int timeout, const uint16_t* request_list, uint8_t* status_list, size_t list_size);
 

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -13,7 +13,6 @@
 #define DELETE_SESSION_MAX_MSG_SIZE 16
 //---
 
-static void flash_output_streams(mrSession* session);
 static bool listen_message(mrSession* session, int poll_ms);
 static bool listen_message_reliably(mrSession* session, int poll_ms);
 
@@ -123,7 +122,7 @@ mrStreamId mr_create_input_reliable_stream(mrSession* session, uint8_t* buffer, 
     return add_input_reliable_buffer(&session->streams, buffer, size, history);
 }
 
-bool mr_run_session_until_timeout(mrSession* session, int timeout_ms)
+bool mr_run_session_time(mrSession* session, int timeout_ms)
 {
     flash_output_streams(session);
 
@@ -134,6 +133,13 @@ bool mr_run_session_until_timeout(mrSession* session, int timeout_ms)
     }
 
     return output_streams_confirmed(&session->streams);
+}
+
+bool mr_run_session_until_timeout(mrSession* session, int timeout_ms)
+{
+    flash_output_streams(session);
+
+    return listen_message_reliably(session, timeout_ms);
 }
 
 bool mr_run_session_until_confirm_delivery(mrSession* session, int timeout_ms)

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -124,7 +124,7 @@ mrStreamId mr_create_input_reliable_stream(mrSession* session, uint8_t* buffer, 
 
 bool mr_run_session_time(mrSession* session, int timeout_ms)
 {
-    flash_output_streams(session);
+    mr_flash_output_streams(session);
 
     bool timeout = false;
     while(!timeout)
@@ -137,14 +137,14 @@ bool mr_run_session_time(mrSession* session, int timeout_ms)
 
 bool mr_run_session_until_timeout(mrSession* session, int timeout_ms)
 {
-    flash_output_streams(session);
+    mr_flash_output_streams(session);
 
     return listen_message_reliably(session, timeout_ms);
 }
 
 bool mr_run_session_until_confirm_delivery(mrSession* session, int timeout_ms)
 {
-    flash_output_streams(session);
+    mr_flash_output_streams(session);
 
     bool timeout = false;
     while(!output_streams_confirmed(&session->streams) && !timeout)
@@ -157,7 +157,7 @@ bool mr_run_session_until_confirm_delivery(mrSession* session, int timeout_ms)
 
 bool mr_run_session_until_status(mrSession* session, int timeout_ms, const uint16_t* request_list, uint8_t* status_list, size_t list_size)
 {
-    flash_output_streams(session);
+    mr_flash_output_streams(session);
 
     for(unsigned i = 0; i < list_size; ++i)
     {
@@ -192,10 +192,7 @@ bool mr_run_session_until_status(mrSession* session, int timeout_ms, const uint1
     return status_ok;
 }
 
-//==================================================================
-//                             PRIVATE
-//==================================================================
-void flash_output_streams(mrSession* session)
+void mr_flash_output_streams(mrSession* session)
 {
     for(uint8_t i = 0; i < session->streams.output_best_effort_size; ++i)
     {
@@ -224,6 +221,9 @@ void flash_output_streams(mrSession* session)
     }
 }
 
+//==================================================================
+//                             PRIVATE
+//==================================================================
 bool listen_message(mrSession* session, int poll_ms)
 {
     uint8_t* data; size_t length;


### PR DESCRIPTION
The changes will be the following:

```c
bool mr_run_session_until_timeout(mrSession* session, int timeout);
```
This function is waiting always the timeout. If a message is received before the timeout, the function will listen for another message. The change is for to listen only one message, exiting before the timeout if the message is received, because the function name seems to indicate this, not its previous behavior.

In order to preserve the before behaviour, a new function will be created:
```c
bool mr_run_session_time(mrSession* session, int time);
```
Also, if the purpose of an user is only to send the stream data to the agent, currently is done with `mr_run_session_until_timeout(session, 0)`, but this will listening a message if it already exists for its reading. For that, if the user want send without listening anything, a new function is added:

```c
void flash_output_streams(mrSession* session):
```