### PR TITLE
bugfix/Disable log compilation if it is not required.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ set(SRCS
     src/c/core/serialization/xrce_header.c
     src/c/core/serialization/xrce_subheader.c
     src/c/core/util/time.c
-    src/c/core/session/log/message.c
+    $<$<OR:$<BOOL:${VERBOSE_MESSAGE}>,$<BOOL:${VERBOSE_SERIALIZATION}>>:src/c/core/session/log/message.c>
     )
 
 ###############################################################################


### PR DESCRIPTION
The `message.c` file used for the logs is always compiled even if the verbose flags are disable. Fixed it.