### PR TITLE
Request change at run_session_until_status

### DIFF
--- a/examples/Deployment/configurator_client.c
+++ b/examples/Deployment/configurator_client.c
@@ -201,7 +201,7 @@ void delete_subscriber(mrSession* session, uint16_t id)
 void wait_status(mrSession* session, uint16_t* requests)
 {
     uint8_t status[4];
-    if(mr_run_session_until_status_and(session, 3000, requests, status, 4))
+    if(mr_run_session_until_all_status(session, 3000, requests, status, 4))
     {
         printf("Ok\n");
     }

--- a/examples/Deployment/configurator_client.c
+++ b/examples/Deployment/configurator_client.c
@@ -201,7 +201,7 @@ void delete_subscriber(mrSession* session, uint16_t id)
 void wait_status(mrSession* session, uint16_t* requests)
 {
     uint8_t status[4];
-    if(mr_run_session_until_status(session, 3000, requests, status, 4))
+    if(mr_run_session_until_status_and(session, 3000, requests, status, 4))
     {
         printf("Ok\n");
     }

--- a/examples/Deployment/subscriber.c
+++ b/examples/Deployment/subscriber.c
@@ -80,7 +80,7 @@ int main(int args, char** argv)
     while(connected)
     {
         uint8_t read_data_status;
-        connected = mr_run_session_until_status_and(&session, MR_TIMEOUT_INF, &read_data_req, &read_data_status, 1);
+        connected = mr_run_session_until_all_status(&session, MR_TIMEOUT_INF, &read_data_req, &read_data_status, 1);
     }
 
     // Delete resources

--- a/examples/Deployment/subscriber.c
+++ b/examples/Deployment/subscriber.c
@@ -80,7 +80,7 @@ int main(int args, char** argv)
     while(connected)
     {
         uint8_t read_data_status;
-        connected = mr_run_session_until_status(&session, MR_TIMEOUT_INF, &read_data_req, &read_data_status, 1);
+        connected = mr_run_session_until_status_and(&session, MR_TIMEOUT_INF, &read_data_req, &read_data_status, 1);
     }
 
     // Delete resources

--- a/examples/PublishHelloWorld/main.c
+++ b/examples/PublishHelloWorld/main.c
@@ -78,7 +78,7 @@ int main(int args, char** argv)
     // Send create entities message and wait its status
     uint8_t status[4];
     uint16_t requests[4] = {participant_req, topic_req, publisher_req, datawriter_req};
-    if(!mr_run_session_until_status_and(&session, 1000, requests, status, 4))
+    if(!mr_run_session_until_all_status(&session, 1000, requests, status, 4))
     {
         printf("Error at create entities: participant: %i topic: %i publisher: %i darawriter: %i\n", status[0], status[1], status[2], status[3]);
         return 1;

--- a/examples/PublishHelloWorld/main.c
+++ b/examples/PublishHelloWorld/main.c
@@ -78,7 +78,7 @@ int main(int args, char** argv)
     // Send create entities message and wait its status
     uint8_t status[4];
     uint16_t requests[4] = {participant_req, topic_req, publisher_req, datawriter_req};
-    if(!mr_run_session_until_status(&session, 1000, requests, status, 4))
+    if(!mr_run_session_until_status_and(&session, 1000, requests, status, 4))
     {
         printf("Error at create entities: participant: %i topic: %i publisher: %i darawriter: %i\n", status[0], status[1], status[2], status[3]);
         return 1;

--- a/examples/SubscribeHelloWorld/main.c
+++ b/examples/SubscribeHelloWorld/main.c
@@ -91,7 +91,7 @@ int main(int args, char** argv)
     // Send create entities message and wait its status
     uint8_t status[4];
     uint16_t requests[4] = {participant_req, topic_req, subscriber_req, datareader_req};
-    if(!mr_run_session_until_status(&session, 1000, requests, status, 4))
+    if(!mr_run_session_until_status_and(&session, 1000, requests, status, 4))
     {
         printf("Error at create entities: participant: %i topic: %i subscriber: %i datareader: %i\n", status[0], status[1], status[2], status[3]);
         return 1;
@@ -107,7 +107,7 @@ int main(int args, char** argv)
     while(connected && count < max_topics)
     {
         uint8_t read_data_status;
-        connected = mr_run_session_until_status(&session, MR_TIMEOUT_INF, &read_data_req, &read_data_status, 1);
+        connected = mr_run_session_until_status_and(&session, MR_TIMEOUT_INF, &read_data_req, &read_data_status, 1);
     }
 
     // Delete resources

--- a/examples/SubscribeHelloWorld/main.c
+++ b/examples/SubscribeHelloWorld/main.c
@@ -91,7 +91,7 @@ int main(int args, char** argv)
     // Send create entities message and wait its status
     uint8_t status[4];
     uint16_t requests[4] = {participant_req, topic_req, subscriber_req, datareader_req};
-    if(!mr_run_session_until_status_and(&session, 1000, requests, status, 4))
+    if(!mr_run_session_until_all_status(&session, 1000, requests, status, 4))
     {
         printf("Error at create entities: participant: %i topic: %i subscriber: %i datareader: %i\n", status[0], status[1], status[2], status[3]);
         return 1;
@@ -107,7 +107,7 @@ int main(int args, char** argv)
     while(connected && count < max_topics)
     {
         uint8_t read_data_status;
-        connected = mr_run_session_until_status_and(&session, MR_TIMEOUT_INF, &read_data_req, &read_data_status, 1);
+        connected = mr_run_session_until_all_status(&session, MR_TIMEOUT_INF, &read_data_req, &read_data_status, 1);
     }
 
     // Delete resources

--- a/include/micrortps/client/core/session/session.h
+++ b/include/micrortps/client/core/session/session.h
@@ -70,8 +70,8 @@ MRDLLAPI void mr_flash_output_streams(mrSession* session);
 MRDLLAPI bool mr_run_session_time(mrSession* session, int time);
 MRDLLAPI bool mr_run_session_until_timeout(mrSession* session, int timeout);
 MRDLLAPI bool mr_run_session_until_confirm_delivery(mrSession* session, int timeout);
-MRDLLAPI bool mr_run_session_until_status_and(mrSession* session, int timeout, const uint16_t* request_list, uint8_t* status_list, size_t list_size);
-MRDLLAPI bool mr_run_session_until_status_or(mrSession* session, int timeout, const uint16_t* request_list, uint8_t* status_list, size_t list_size);
+MRDLLAPI bool mr_run_session_until_all_status(mrSession* session, int timeout, const uint16_t* request_list, uint8_t* status_list, size_t list_size);
+MRDLLAPI bool mr_run_session_until_one_status(mrSession* session, int timeout, const uint16_t* request_list, uint8_t* status_list, size_t list_size);
 
 #ifdef __cplusplus
 }

--- a/include/micrortps/client/core/session/session.h
+++ b/include/micrortps/client/core/session/session.h
@@ -70,7 +70,8 @@ MRDLLAPI void mr_flash_output_streams(mrSession* session);
 MRDLLAPI bool mr_run_session_time(mrSession* session, int time);
 MRDLLAPI bool mr_run_session_until_timeout(mrSession* session, int timeout);
 MRDLLAPI bool mr_run_session_until_confirm_delivery(mrSession* session, int timeout);
-MRDLLAPI bool mr_run_session_until_status(mrSession* session, int timeout, const uint16_t* request_list, uint8_t* status_list, size_t list_size);
+MRDLLAPI bool mr_run_session_until_status_and(mrSession* session, int timeout, const uint16_t* request_list, uint8_t* status_list, size_t list_size);
+MRDLLAPI bool mr_run_session_until_status_or(mrSession* session, int timeout, const uint16_t* request_list, uint8_t* status_list, size_t list_size);
 
 #ifdef __cplusplus
 }

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -155,7 +155,7 @@ bool mr_run_session_until_confirm_delivery(mrSession* session, int timeout_ms)
     return output_streams_confirmed(&session->streams);
 }
 
-bool mr_run_session_until_status_and(mrSession* session, int timeout_ms, const uint16_t* request_list, uint8_t* status_list, size_t list_size)
+bool mr_run_session_until_all_status(mrSession* session, int timeout_ms, const uint16_t* request_list, uint8_t* status_list, size_t list_size)
 {
     mr_flash_output_streams(session);
 
@@ -192,7 +192,7 @@ bool mr_run_session_until_status_and(mrSession* session, int timeout_ms, const u
     return status_ok;
 }
 
-bool mr_run_session_until_status_or(mrSession* session, int timeout_ms, const uint16_t* request_list, uint8_t* status_list, size_t list_size)
+bool mr_run_session_until_one_status(mrSession* session, int timeout_ms, const uint16_t* request_list, uint8_t* status_list, size_t list_size)
 {
     mr_flash_output_streams(session);
 

--- a/src/c/profile/transport/serial_transport_linux.c
+++ b/src/c/profile/transport/serial_transport_linux.c
@@ -87,7 +87,7 @@ static bool recv_serial_msg(void* instance, uint8_t** buf, size_t* len, int time
     return rv;
 }
 
-static int get_serial_error()
+static int get_serial_error(void)
 {
     return serial_errno;
 }

--- a/src/c/profile/transport/tcp_transport_linux.c
+++ b/src/c/profile/transport/tcp_transport_linux.c
@@ -11,7 +11,7 @@
  *******************************************************************************/
 static bool send_tcp_msg(void* instance, const uint8_t* buf, size_t len);
 static bool recv_tcp_msg(void* instance, uint8_t** buf, size_t* len, int timeout);
-static int get_tcp_error();
+static int get_tcp_error(void);
 static uint16_t read_tcp_data(mrTCPTransport* transport);
 static inline void disconnect_tcp(mrTCPTransport* transport);
 
@@ -98,7 +98,7 @@ bool recv_tcp_msg(void* instance, uint8_t** buf, size_t* len, int timeout)
     return rv;
 }
 
-int get_tcp_error()
+int get_tcp_error(void)
 {
     return errno;
 }

--- a/src/c/profile/transport/tcp_transport_windows.c
+++ b/src/c/profile/transport/tcp_transport_windows.c
@@ -5,7 +5,7 @@
  *******************************************************************************/
 static bool send_tcp_msg(void* instance, const uint8_t* buf, size_t len);
 static bool recv_tcp_msg(void* instance, uint8_t** buf, size_t* len, int timeout);
-static int get_tcp_error();
+static int get_tcp_error(void);
 
 /*******************************************************************************
  * Private function definitions.
@@ -61,7 +61,7 @@ static bool recv_tcp_msg(void* instance, uint8_t** buf, size_t* len, int timeout
     return rv;
 }
 
-static int get_tcp_error()
+static int get_tcp_error(void)
 {
     return WSAGetLastError();
 }

--- a/src/c/profile/transport/udp_transport_linux.c
+++ b/src/c/profile/transport/udp_transport_linux.c
@@ -11,7 +11,7 @@
  *******************************************************************************/
 static bool send_udp_msg(void* instance, const uint8_t* buf, size_t len);
 static bool recv_udp_msg(void* instance, uint8_t** buf, size_t* len, int timeout);
-static int get_udp_error();
+static int get_udp_error(void);
 
 /*******************************************************************************
  * Private function definitions.
@@ -62,7 +62,7 @@ static bool recv_udp_msg(void* instance, uint8_t** buf, size_t* len, int timeout
     return rv;
 }
 
-static int get_udp_error()
+static int get_udp_error(void)
 {
     return errno;
 }

--- a/src/c/profile/transport/udp_transport_windows.c
+++ b/src/c/profile/transport/udp_transport_windows.c
@@ -5,7 +5,7 @@
  *******************************************************************************/
 static bool send_udp_msg(void* instance, const uint8_t* buf, size_t len);
 static bool recv_udp_msg(void* instance, uint8_t** buf, size_t* len, int timeout);
-static int get_udp_error();
+static int get_udp_error(void);
 
 /*******************************************************************************
  * Private function definitions.
@@ -52,7 +52,7 @@ static bool recv_udp_msg(void* instance, uint8_t** buf, size_t* len, int timeout
     return rv;
 }
 
-static int get_udp_error()
+static int get_udp_error(void)
 {
     return WSAGetLastError();
 }

--- a/test/integration/interaction/ClientInteraction.hpp
+++ b/test/integration/interaction/ClientInteraction.hpp
@@ -43,37 +43,37 @@ public:
         mrObjectId participant_id = mr_object_id(id, MR_PARTICIPANT_ID);
         request_id = mr_write_create_participant_ref(&session_, output_stream_id, participant_id, 0, "default_xrce_participant_profile", flags);
         ASSERT_NE(MR_INVALID_REQUEST_ID, request_id);
-        mr_run_session_until_status(&session_, 60000, &request_id, &status, 1);
+        mr_run_session_until_status_and(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
 
         mrObjectId topic_id = mr_object_id(id, MR_TOPIC_ID);
         request_id = mr_write_configure_topic_xml(&session_, output_stream_id, topic_id, participant_id, topic_xml_, flags);
         ASSERT_NE(MR_INVALID_REQUEST_ID, request_id);
-        mr_run_session_until_status(&session_, 60000, &request_id, &status, 1);
+        mr_run_session_until_status_and(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
 
         mrObjectId publisher_id = mr_object_id(id, MR_PUBLISHER_ID);
         request_id = mr_write_configure_publisher_xml(&session_, output_stream_id, publisher_id, participant_id, publisher_xml_, flags);
         ASSERT_NE(MR_INVALID_REQUEST_ID, request_id);
-        mr_run_session_until_status(&session_, 60000, &request_id, &status, 1);
+        mr_run_session_until_status_and(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
 
         mrObjectId datawriter_id = mr_object_id(id, MR_DATAWRITER_ID);
         request_id = mr_write_configure_datawriter_xml(&session_, output_stream_id, datawriter_id, publisher_id, datawriter_xml_, flags);
         ASSERT_NE(MR_INVALID_REQUEST_ID, request_id);
-        mr_run_session_until_status(&session_, 60000, &request_id, &status, 1);
+        mr_run_session_until_status_and(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
 
         mrObjectId subscriber_id = mr_object_id(id, MR_SUBSCRIBER_ID);
         request_id = mr_write_configure_subscriber_xml(&session_, output_stream_id, subscriber_id, participant_id, subscriber_xml_, flags);
         ASSERT_NE(MR_INVALID_REQUEST_ID, request_id);
-        mr_run_session_until_status(&session_, 60000, &request_id, &status, 1);
+        mr_run_session_until_status_and(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
 
         mrObjectId datareader_id = mr_object_id(id, MR_DATAREADER_ID);
         request_id = mr_write_configure_datareader_xml(&session_, output_stream_id, datareader_id, subscriber_id, datareader_xml_, flags);
         ASSERT_NE(MR_INVALID_REQUEST_ID, request_id);
-        mr_run_session_until_status(&session_, 60000, &request_id, &status, 1);
+        mr_run_session_until_status_and(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
     }
 
@@ -119,7 +119,7 @@ public:
         while(expected_topic_index_ < number)
         {
             uint8_t status;
-            bool received_ok = mr_run_session_until_status(&session_, 60000, &request_id, &status, 1);
+            bool received_ok = mr_run_session_until_status_and(&session_, 60000, &request_id, &status, 1);
             ASSERT_EQ(MR_STATUS_OK, status);
             ASSERT_TRUE(received_ok);
             //ASSERT_EQ(last_topic_object_id_, datareader_id);

--- a/test/integration/interaction/ClientInteraction.hpp
+++ b/test/integration/interaction/ClientInteraction.hpp
@@ -43,37 +43,37 @@ public:
         mrObjectId participant_id = mr_object_id(id, MR_PARTICIPANT_ID);
         request_id = mr_write_create_participant_ref(&session_, output_stream_id, participant_id, 0, "default_xrce_participant_profile", flags);
         ASSERT_NE(MR_INVALID_REQUEST_ID, request_id);
-        mr_run_session_until_status_and(&session_, 60000, &request_id, &status, 1);
+        mr_run_session_until_all_status(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
 
         mrObjectId topic_id = mr_object_id(id, MR_TOPIC_ID);
         request_id = mr_write_configure_topic_xml(&session_, output_stream_id, topic_id, participant_id, topic_xml_, flags);
         ASSERT_NE(MR_INVALID_REQUEST_ID, request_id);
-        mr_run_session_until_status_and(&session_, 60000, &request_id, &status, 1);
+        mr_run_session_until_all_status(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
 
         mrObjectId publisher_id = mr_object_id(id, MR_PUBLISHER_ID);
         request_id = mr_write_configure_publisher_xml(&session_, output_stream_id, publisher_id, participant_id, publisher_xml_, flags);
         ASSERT_NE(MR_INVALID_REQUEST_ID, request_id);
-        mr_run_session_until_status_and(&session_, 60000, &request_id, &status, 1);
+        mr_run_session_until_all_status(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
 
         mrObjectId datawriter_id = mr_object_id(id, MR_DATAWRITER_ID);
         request_id = mr_write_configure_datawriter_xml(&session_, output_stream_id, datawriter_id, publisher_id, datawriter_xml_, flags);
         ASSERT_NE(MR_INVALID_REQUEST_ID, request_id);
-        mr_run_session_until_status_and(&session_, 60000, &request_id, &status, 1);
+        mr_run_session_until_all_status(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
 
         mrObjectId subscriber_id = mr_object_id(id, MR_SUBSCRIBER_ID);
         request_id = mr_write_configure_subscriber_xml(&session_, output_stream_id, subscriber_id, participant_id, subscriber_xml_, flags);
         ASSERT_NE(MR_INVALID_REQUEST_ID, request_id);
-        mr_run_session_until_status_and(&session_, 60000, &request_id, &status, 1);
+        mr_run_session_until_all_status(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
 
         mrObjectId datareader_id = mr_object_id(id, MR_DATAREADER_ID);
         request_id = mr_write_configure_datareader_xml(&session_, output_stream_id, datareader_id, subscriber_id, datareader_xml_, flags);
         ASSERT_NE(MR_INVALID_REQUEST_ID, request_id);
-        mr_run_session_until_status_and(&session_, 60000, &request_id, &status, 1);
+        mr_run_session_until_all_status(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
     }
 
@@ -119,7 +119,7 @@ public:
         while(expected_topic_index_ < number)
         {
             uint8_t status;
-            bool received_ok = mr_run_session_until_status_and(&session_, 60000, &request_id, &status, 1);
+            bool received_ok = mr_run_session_until_all_status(&session_, 60000, &request_id, &status, 1);
             ASSERT_EQ(MR_STATUS_OK, status);
             ASSERT_TRUE(received_ok);
             //ASSERT_EQ(last_topic_object_id_, datareader_id);


### PR DESCRIPTION
Currently we have the next function:
```c
bool mr_run_session_until_status(mrSession* session, int timeout, const uint16_t* request_list, uint8_t* status_list, size_t list_size);
```
This function exits when **all** status were received (or timeout). It is possible that the user required a function that exits only when **one** status of them was received. For that, it is interesting change the previous function into the following two (with the same signature):
```c
mr_run_session_until_all_status (same behaviour as the current)
mr_run_session_until_one_status
```
