### PR TITLE
Fix added prefix by error.

### DIFF
--- a/include/micrortps/client/core/serialization/xrce_header.h
+++ b/include/micrortps/client/core/serialization/xrce_header.h
@@ -32,8 +32,8 @@ extern "C"
 #define SESSION_ID_WITH_CLIENT_KEY 0x00
 #define SESSION_ID_WITHOUT_CLIENT_KEY 0x80
 
-void mc_serialize_message_header(mcBuffer* mb, uint8_t session_id, uint8_t stream_id, uint16_t seq_num, const uint8_t* key);
-void mc_deserialize_message_header(mcBuffer* mb, uint8_t* session_id, uint8_t* stream_id, uint16_t* seq_num, uint8_t* key);
+void serialize_message_header(mcBuffer* mb, uint8_t session_id, uint8_t stream_id, uint16_t seq_num, const uint8_t* key);
+void deserialize_message_header(mcBuffer* mb, uint8_t* session_id, uint8_t* stream_id, uint16_t* seq_num, uint8_t* key);
 
 #ifdef __cplusplus
 }

--- a/include/micrortps/client/core/serialization/xrce_subheader.h
+++ b/include/micrortps/client/core/serialization/xrce_subheader.h
@@ -24,8 +24,8 @@ extern "C"
 #include <stdbool.h>
 #include <microcdr/microcdr.h>
 
-void mc_serialize_submessage_header(mcBuffer* buffer, uint8_t id, uint8_t flags, uint16_t length);
-void mc_deserialize_submessage_header(mcBuffer* buffer, uint8_t* id, uint8_t* flags, uint16_t* length);
+void serialize_submessage_header(mcBuffer* buffer, uint8_t id, uint8_t flags, uint16_t length);
+void deserialize_submessage_header(mcBuffer* buffer, uint8_t* id, uint8_t* flags, uint16_t* length);
 
 #ifdef __cplusplus
 }

--- a/src/c/core/serialization/xrce_header.c
+++ b/src/c/core/serialization/xrce_header.c
@@ -3,7 +3,7 @@
 //==================================================================
 //                             PUBLIC
 //==================================================================
-void mc_serialize_message_header(mcBuffer* mb, uint8_t session_id, uint8_t stream_id, uint16_t seq_num, const uint8_t* key)
+void serialize_message_header(mcBuffer* mb, uint8_t session_id, uint8_t stream_id, uint16_t seq_num, const uint8_t* key)
 {
     (void) mc_serialize_uint8_t(mb, session_id);
     (void) mc_serialize_uint8_t(mb, stream_id);
@@ -14,7 +14,7 @@ void mc_serialize_message_header(mcBuffer* mb, uint8_t session_id, uint8_t strea
     }
 }
 
-void mc_deserialize_message_header(mcBuffer* mb, uint8_t* session_id, uint8_t* stream_id, uint16_t* seq_num, uint8_t* key)
+void deserialize_message_header(mcBuffer* mb, uint8_t* session_id, uint8_t* stream_id, uint16_t* seq_num, uint8_t* key)
 {
     (void) mc_deserialize_uint8_t(mb, session_id);
     (void) mc_deserialize_uint8_t(mb, stream_id);

--- a/src/c/core/serialization/xrce_subheader.c
+++ b/src/c/core/serialization/xrce_subheader.c
@@ -3,14 +3,14 @@
 //==================================================================
 //                             PUBLIC
 //==================================================================
-void mc_serialize_submessage_header(mcBuffer* mb, uint8_t id, uint8_t flags, uint16_t length)
+void serialize_submessage_header(mcBuffer* mb, uint8_t id, uint8_t flags, uint16_t length)
 {
     (void) mc_serialize_uint8_t(mb, id);
     (void) mc_serialize_uint8_t(mb, flags);
     (void) mc_serialize_endian_uint16_t(mb, MC_LITTLE_ENDIANNESS, length);
 }
 
-void mc_deserialize_submessage_header(mcBuffer* mb, uint8_t* id, uint8_t* flags, uint16_t* length)
+void deserialize_submessage_header(mcBuffer* mb, uint8_t* id, uint8_t* flags, uint16_t* length)
 {
     (void) mc_deserialize_uint8_t(mb, id);
     (void) mc_deserialize_uint8_t(mb, flags);

--- a/src/c/core/session/log/message.c
+++ b/src/c/core/session/log/message.c
@@ -77,7 +77,7 @@ void print_message(int direction, uint8_t* buffer, size_t size, const uint8_t* c
     mc_init_buffer(&mb, buffer, (uint32_t)size);
 
     uint8_t session_id; uint8_t stream_id_raw; uint16_t seq_num; uint8_t key[CLIENT_KEY_SIZE];
-    (void) mc_deserialize_message_header(&mb, &session_id, &stream_id_raw, &seq_num, key);
+    (void) deserialize_message_header(&mb, &session_id, &stream_id_raw, &seq_num, key);
 
     print_header(size, direction, stream_id_raw, seq_num, client_key);
 

--- a/src/c/core/session/session_info.c
+++ b/src/c/core/session/session_info.c
@@ -88,7 +88,7 @@ void stamp_create_session_header(const mrSessionInfo* info, uint8_t* buffer)
     mcBuffer mb;
     mc_init_buffer(&mb, buffer, MAX_HEADER_SIZE);
 
-    (void) mc_serialize_message_header(&mb, info->id & SESSION_ID_WITHOUT_CLIENT_KEY, 0, 0, info->key);
+    (void) serialize_message_header(&mb, info->id & SESSION_ID_WITHOUT_CLIENT_KEY, 0, 0, info->key);
 }
 
 void stamp_session_header(const mrSessionInfo* info, uint8_t stream_id_raw, mrSeqNum seq_num, uint8_t* buffer)
@@ -96,7 +96,7 @@ void stamp_session_header(const mrSessionInfo* info, uint8_t stream_id_raw, mrSe
     mcBuffer mb;
     mc_init_buffer(&mb, buffer, MAX_HEADER_SIZE);
 
-    (void) mc_serialize_message_header(&mb, info->id, stream_id_raw, seq_num, info->key);
+    (void) serialize_message_header(&mb, info->id, stream_id_raw, seq_num, info->key);
 }
 
 bool read_session_header(const mrSessionInfo* info, mcBuffer* mb, uint8_t* stream_id_raw, mrSeqNum* seq_num)
@@ -105,7 +105,7 @@ bool read_session_header(const mrSessionInfo* info, mcBuffer* mb, uint8_t* strea
     if(must_be_read)
     {
         uint8_t session_id; uint8_t key[CLIENT_KEY_SIZE];
-        (void) mc_deserialize_message_header(mb, &session_id, stream_id_raw, seq_num, key);
+        (void) deserialize_message_header(mb, &session_id, stream_id_raw, seq_num, key);
 
         must_be_read = session_id == info->id;
         if(must_be_read)

--- a/src/c/core/session/submessage.c
+++ b/src/c/core/session/submessage.c
@@ -11,7 +11,7 @@ bool write_submessage_header(mcBuffer* mb, uint8_t submessage_id, uint16_t lengt
     mc_align_to(mb, 4);
     mb->endianness = MC_MACHINE_ENDIANNESS;
     flags = (uint8_t)(flags | mb->endianness);
-    mc_serialize_submessage_header(mb, submessage_id, flags, length);
+    serialize_submessage_header(mb, submessage_id, flags, length);
 
     return mc_buffer_remaining(mb) >= length;
 }
@@ -27,7 +27,7 @@ bool read_submessage_header(mcBuffer* mb, uint8_t* submessage_id, uint16_t* leng
     bool ready_to_read = mc_buffer_remaining(mb) >= SUBHEADER_SIZE;
     if(ready_to_read)
     {
-        mc_deserialize_submessage_header(mb, submessage_id, flags, length);
+        deserialize_submessage_header(mb, submessage_id, flags, length);
 
         uint8_t endiannes_flag = *flags & FLAG_ENDIANNESS;
         *flags = (uint8_t)(*flags & ~endiannes_flag);


### PR DESCRIPTION
Added an "mc_" prefix to a functions that not belong to MicroCDR. Fix it.